### PR TITLE
Lots of changes to package the build properly

### DIFF
--- a/Source/Bomber/Bomb.cpp
+++ b/Source/Bomber/Bomb.cpp
@@ -33,8 +33,8 @@ ABomb::ABomb()
 	}
 
 	// Initialize explosion particle component
-	ExplosionParticle = CreateDefaultSubobject<UParticleSystem>(TEXT("Explosion Particle"));
-	static ConstructorHelpers::FObjectFinder<UParticleSystem> ParticleFinder(TEXT("/Game/VFX_Toolkit_V1/ParticleSystems/356Days/Par_CrescentBoom2_OLD"));
+	ExplosionParticle = CreateDefaultSubobject<UParticleSystem>(TEXT("ExplosionParticle"));
+	static ConstructorHelpers::FObjectFinder<UParticleSystem> ParticleFinder(TEXT("/Game/FXVarietyPack/Particles/P_ky_explosion"));
 	if (ParticleFinder.Succeeded())
 	{
 		ExplosionParticle = ParticleFinder.Object;
@@ -81,7 +81,7 @@ void ABomb::InitializeBombProperties(
 
 	// Set material
 	if (IS_VALID(BombMeshComponent) == true  // Mesh of the bomb is not valid
-		&& CharacterID > 0)					 // No materials for the negative ID
+		&& CharacterID != -1)				 // is not debug character
 	{
 		const int32 BombMaterialNo = FMath::Abs(CharacterID) % BombMaterials_.Num();
 		BombMeshComponent->SetMaterial(0, BombMaterials_[BombMaterialNo]);

--- a/Source/Bomber/Bomb.cpp
+++ b/Source/Bomber/Bomb.cpp
@@ -118,15 +118,14 @@ void ABomb::OnConstruction(const FTransform& Transform)
 	// Construct the actor's map component
 	MapComponent->OnMapComponentConstruction();
 
-#if WITH_EDITOR
-	if (IS_PIE(GetWorld()) == true						  // for editor only
-		&& USingletonLibrary::GetSingleton() != nullptr)  // Singleton is not null
+#if WITH_EDITOR										   // [IsEditorNotPieWorld]
+	if (USingletonLibrary::IsEditorNotPieWorld(this))  // for editor only
 	{
 		InitializeBombProperties(*CharacterBombsN_, ExplosionLength, -1);
-		USingletonLibrary::PrintToLog(this, "[PIE]OnConstruction", "-> \t AddDebugTextRenders");
+		USingletonLibrary::PrintToLog(this, "[IsEditorNotPieWorld]OnConstruction", "-> \t AddDebugTextRenders");
 		USingletonLibrary::AddDebugTextRenders(this, ExplosionCells_, FLinearColor::Red);
 	}
-#endif  //WITH_EDITOR [PIE]
+#endif  //WITH_EDITOR [IsEditorNotPieWorld]
 }
 
 void ABomb::OnBombDestroyed(AActor* DestroyedActor)

--- a/Source/Bomber/Bomber.h
+++ b/Source/Bomber/Bomber.h
@@ -5,11 +5,10 @@
 #include "Engine\World.h"
 #include "Kismet/GameplayStatics.h"
 
-//@todo Is includes the transient world as IsGameWorld() ? //!(Obj)->GetWorld()->IsGameWorld()
-#define IS_TRANSIENT(Obj) ((Obj)->HasAllFlags(RF_Transient) || (Obj)->GetWorld() == nullptr || UGameplayStatics::GetCurrentLevelName((Obj)->GetWorld()) == "Transient")
-#define IS_VALID(Obj) (IsValid(Obj) && (Obj)->IsValidLowLevel() && !IS_TRANSIENT(Obj))
+//@todo Is includes the transient world as IsEditorWorld() ? //!(Obj)->GetWorld()->IsGameWorld()
+#define IS_TRANSIENT(Obj) (!(Obj)->IsValidLowLevel() || (Obj)->HasAllFlags(RF_Transient) || (Obj)->GetWorld() == nullptr || UGameplayStatics::GetCurrentLevelName((Obj)->GetWorld()) == "Transient")
+#define IS_VALID(Obj) (IsValid(Obj) && !IS_TRANSIENT(Obj))
 
-#define IS_PIE(World) (ensureMsgf(World != nullptr, TEXT("World is null")) && World->HasBegunPlay() == false && (World->WorldType == EWorldType::Editor))
 #define TO_FLAG(Enum) static_cast<int32>(Enum)
 
 /**
@@ -34,12 +33,13 @@ enum class EPathTypesEnum : uint8
 UENUM(BlueprintType, meta = (Bitflags, UseEnumValuesAsMaskValuesInEditor = "true"))
 enum class EActorTypeEnum : uint8
 {
-	None = 0,		  ///< None of the types for comparisons
-	Bomb = 1 << 0,	///< A destroyable exploding Obstacle
-	Item = 1 << 1,	///< A picked element giving power-up (FPowerUp struct)
-	Player = 1 << 2,  ///< A character that is controlled by a person or bot
-	Wall = 1 << 3,	///< An absolute static and unchangeable block throughout the game
-	Box = 1 << 4,	 ///< A destroyable Obstacle
+	None = 0,								 ///< None of the types for comparisons
+	Bomb = 1 << 0,							 ///< A destroyable exploding Obstacle
+	Item = 1 << 1,							 ///< A picked element giving power-up (FPowerUp struct)
+	Player = 1 << 2,						 ///< A character that is controlled by a person or bot
+	Wall = 1 << 3,							 ///< An absolute static and unchangeable block throughout the game
+	Box = 1 << 4,							 ///< A destroyable Obstacle
+	All = Bomb | Item | Player | Wall | Box  ///< All level actors
 };
 
 /** @addtogroup actor_types

--- a/Source/Bomber/MapComponent.h
+++ b/Source/Bomber/MapComponent.h
@@ -28,13 +28,9 @@ public:
 	struct FCell Cell;
 
 protected:
-	/**
-	 * Called when a component is created (not loaded)
-	 * Sets owner's defaults
-	 */
-	virtual void OnComponentCreated() final;
+	/** Called when a component is registered (not loaded) */
+	virtual void OnRegister() final;
 
 	/* Called when a component is destroyed */
 	virtual void OnComponentDestroyed(bool bDestroyingHierarchy) final;
-	;
 };

--- a/Source/Bomber/MyAiCharacter.cpp
+++ b/Source/Bomber/MyAiCharacter.cpp
@@ -15,11 +15,11 @@ void AMyAiCharacter::UpdateAI_Implementation()
 	}
 
 #if WITH_EDITOR
-	if (IS_PIE(GetWorld()) == true)  // for editor only
+	if (USingletonLibrary::IsEditorNotPieWorld(this))  // for editor only
 	{
-		USingletonLibrary::PrintToLog(this, "[PIE]UpdateAI", "-> \t ClearOwnerTextRenders");
+		USingletonLibrary::PrintToLog(this, "IsEditorNotPieWorldUpdateAI", "-> \t ClearOwnerTextRenders");
 		USingletonLibrary::ClearOwnerTextRenders(this);
 		AiMoveTo = FCell::ZeroCell;
 	}
-#endif  //WITH_EDITOR [PIE]
+#endif  //WITH_EDITOR IsEditorNotPieWorld
 }

--- a/Source/Bomber/MyCharacter.cpp
+++ b/Source/Bomber/MyCharacter.cpp
@@ -21,7 +21,7 @@ AMyCharacter::AMyCharacter()
 	MapComponent = CreateDefaultSubobject<UMapComponent>(TEXT("MapComponent"));
 
 	// Initialize skeletal mesh
-	GetMesh()->SetRelativeLocationAndRotation(FVector(0, 0, -90), FRotator(0, -90, 0));
+	GetMesh()->SetRelativeLocationAndRotation(FVector(0, 0, -90.f), FRotator(0, -90.f, 0));
 
 	// Set the skeletal mesh
 	static ConstructorHelpers::FObjectFinder<USkeletalMesh> SkeletalMeshFinder(TEXT("/Game/ParagonIggyScorch/Characters/Heroes/IggyScorch/Meshes/IggyScorch"));
@@ -31,7 +31,7 @@ AMyCharacter::AMyCharacter()
 	}
 
 	// Set the animation
-	static ConstructorHelpers::FObjectFinder<UAnimBlueprint> AnimationFinder(TEXT("/Game/ParagonIggyScorch/Characters/Heroes/IggyScorch/IggyScorch_AnimBP"));
+	static ConstructorHelpers::FObjectFinder<UAnimBlueprint> AnimationFinder(TEXT("AnimBlueprint'/Game/ParagonIggyScorch/Characters/Heroes/IggyScorch/IggyScorch_AnimBP.IggyScorch_AnimBP'"));
 	if (AnimationFinder.Succeeded())  // The animation was found
 	{
 		GetMesh()->AnimClass = AnimationFinder.Object->GeneratedClass;
@@ -57,7 +57,8 @@ void AMyCharacter::OnConstruction(const FTransform& Transform)
 	MapComponent->OnMapComponentConstruction();
 
 	// Rotate character
-	SetActorRotation(FRotator(0.f, -90.f, 0.f));
+	const float YawRotation = USingletonLibrary::GetLevelMap()->GetActorRotation().Yaw - 90.f;
+	SetActorRotation(FRotator(0.f, YawRotation, 0.f));
 	USingletonLibrary::PrintToLog(this, "OnConstruction \t New rotation:", GetActorRotation().ToString());
 }
 
@@ -78,10 +79,10 @@ void AMyCharacter::Destroyed()
 
 void AMyCharacter::SpawnBomb()
 {
-	if (!IS_VALID(USingletonLibrary::GetLevelMap())  // The Level Map is not valid
-		|| Powerups_.FireN <= 0						 // Null length of explosion
-		|| Powerups_.BombN <= 0						 // No more bombs
-		|| IS_PIE(GetWorld()) == true)				 // Should not spawn bomb in PIE
+	if (!IS_VALID(USingletonLibrary::GetLevelMap())		  // The Level Map is not valid
+		|| Powerups_.FireN <= 0							  // Null length of explosion
+		|| Powerups_.BombN <= 0							  // No more bombs
+		|| USingletonLibrary::IsEditorNotPieWorld(this))  // Should not spawn bomb in PIE
 	{
 		return;
 	}

--- a/Source/Bomber/SingletonLibrary.h
+++ b/Source/Bomber/SingletonLibrary.h
@@ -36,11 +36,7 @@ public:
 
 	/** Checks, that this actor placed in the editor world and the game is not started yet */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "C++", meta = (DevelopmentOnly))
-	static FORCEINLINE bool IsEditorNotPieWorld(const AActor* Actor)
-	{
-		UWorld* World = Actor ? Actor->GetWorld() : nullptr;
-		return ensure(World) && !World->HasBegunPlay() && (World->WorldType == EWorldType::Editor);
-	}
+	static bool IsEditorNotPieWorld(const class AActor* Actor);
 
 	/** Blueprint debug function, that prints messages to the log */
 	UFUNCTION(BlueprintCallable, Category = "C++", meta = (DevelopmentOnly, AutoCreateRefTerm = "FunctionName,Message"))  //

--- a/Source/Bomber/WallActor.cpp
+++ b/Source/Bomber/WallActor.cpp
@@ -28,12 +28,6 @@ AWallActor::AWallActor()
 	{
 		WallMeshComponent->SetStaticMesh(WallMeshFinder.Object);
 	}
-
-	// Initialize the Wall Collision Component to prevent players from moving through the wall
-	UBoxComponent* const WallCollisionComponent = CreateDefaultSubobject<UBoxComponent>("ItemCollisionComponent");
-	WallCollisionComponent->SetupAttachment(RootComponent);
-	WallCollisionComponent->SetBoxExtent(FVector(100.f));
-	WallCollisionComponent->SetCollisionResponseToAllChannels(ECR_Block);
 }
 
 void AWallActor::OnConstruction(const FTransform& Transform)


### PR DESCRIPTION
- IS_PIE macro rewrote to blueprintable function IsEditorNotPieWorld - I was mistaken in thinking that PIE mean is before press the play button.
- Added blueprintable development function BroadcastActorsUpdating to control, that all calls are in IsEditorNotPieWorld 
- All background assets of the Level Map now in one blueprint as BackgroundBlueprintComponent.
- Added the All flag to EActorTypeEnum to be able to select all flags.
- Definitions are sorted in the same order as their declarations.
- More logs added.
- In the MapComponent class, function OnComponentCreated changed to OnRegister in order to binds the owners before onconstruction and ongeneration of the level map.
- The wall static mesh now has simplified box collision, therefore no need in the Box Collision component and it removed from the Wall class.
- After updating to version 4.23 (preview 5), the old emitter no longer works, so it is replaced.
- Nicknames are no longer erased.