### PR TITLE
Fixed issue with low fps halfway transition is not get fired

### DIFF
--- a/Plugins/GameFeatures/NewMainMenu/Source/NewMainMenu/Private/Subsystems/NMMCameraSubsystem.cpp
+++ b/Plugins/GameFeatures/NewMainMenu/Source/NewMainMenu/Private/Subsystems/NMMCameraSubsystem.cpp
@@ -266,7 +266,7 @@ void UNMMCameraSubsystem::TickTransition(float DeltaTime)
 	// checks if it's halfway of transition
 	constexpr float HalfwayPosition = 0.5f;
 	if (CameraRailTransitionStateInternal != ENMMCameraRailTransitionState::HalfwayTransition &&
-		FMath::IsNearlyEqual(Progress, HalfwayPosition, KINDA_SMALL_NUMBER))
+		FMath::IsNearlyEqual(Progress, HalfwayPosition, GetWorld()->DeltaTimeSeconds ))
 	{
 		SetNewCameraRailTransitionState(ENMMCameraRailTransitionState::HalfwayTransition);
 	}

--- a/Plugins/GameFeatures/NewMainMenu/Source/NewMainMenu/Private/Subsystems/NMMCameraSubsystem.cpp
+++ b/Plugins/GameFeatures/NewMainMenu/Source/NewMainMenu/Private/Subsystems/NMMCameraSubsystem.cpp
@@ -266,7 +266,7 @@ void UNMMCameraSubsystem::TickTransition(float DeltaTime)
 	// checks if it's halfway of transition
 	constexpr float HalfwayPosition = 0.5f;
 	if (CameraRailTransitionStateInternal != ENMMCameraRailTransitionState::HalfwayTransition &&
-		FMath::IsNearlyEqual(Progress, HalfwayPosition, GetWorld()->DeltaTimeSeconds ))
+		FMath::IsNearlyEqual(Progress, HalfwayPosition, DeltaTime))
 	{
 		SetNewCameraRailTransitionState(ENMMCameraRailTransitionState::HalfwayTransition);
 	}


### PR DESCRIPTION
https://trello.com/c/WEgNEvly/768-highbugps-progression-system-does-not-block-switched-character-from-rails-in-menu-on-low-fps

[High][Bug][PS] Progression System does not block switched character from rails in Menu on low FPS

The root cause was main menu did not fire correctly at the halfway transition