### PR TITLE
Fixed bug with cutscene start with locked skin

### DIFF
--- a/Plugins/GameFeatures/NewMainMenu/Source/NewMainMenu/Private/Components/NMMSpotComponent.cpp
+++ b/Plugins/GameFeatures/NewMainMenu/Source/NewMainMenu/Private/Components/NMMSpotComponent.cpp
@@ -52,6 +52,13 @@ bool UNMMSpotComponent::IsSpotAvailable() const
 		&& MeshComponent->IsVisible();
 }
 
+// Returns true if this spot current skin is unlocked and can be selected by player
+bool UNMMSpotComponent::IsSpotSkinAvailable() const
+{
+	const UMySkeletalMeshComponent* MeshComponent = GetMySkeletalMeshComponent();
+	return MeshComponent && MeshComponent->IsSkinAvailable(MeshComponent->GetAppliedSkinIndex());
+}
+
 // Returns the Skeletal Mesh of the Bomber character
 UMySkeletalMeshComponent* UNMMSpotComponent::GetMySkeletalMeshComponent() const
 {

--- a/Plugins/GameFeatures/NewMainMenu/Source/NewMainMenu/Private/Widgets/NewMainMenuWidget.cpp
+++ b/Plugins/GameFeatures/NewMainMenu/Source/NewMainMenu/Private/Widgets/NewMainMenuWidget.cpp
@@ -96,6 +96,12 @@ void UNewMainMenuWidget::OnPlayButtonPressed()
 		// The spot is locked
 		return;
 	}
+	
+	if (!MainMenuSpot->IsSpotSkinAvailable())
+	{
+		// the spot's skin unavailable 
+		return;
+	}
 
 	USoundsSubsystem::Get().PlayUIClickSFX();
 

--- a/Plugins/GameFeatures/NewMainMenu/Source/NewMainMenu/Public/Components/NMMSpotComponent.h
+++ b/Plugins/GameFeatures/NewMainMenu/Source/NewMainMenu/Public/Components/NMMSpotComponent.h
@@ -41,6 +41,11 @@ public:
 	UFUNCTION(BlueprintPure, Category = "C++")
 	bool IsSpotAvailable() const;
 
+	/** Returns true if this spot current skin is unlocked and can be selected by player.
+	 * To make this spot skin unavailable, call SetSkinAvailable(false, skinIndex) on this spot on its skeletal mesh. */
+	UFUNCTION(BlueprintPure, Category = "C++")
+	bool IsSpotSkinAvailable() const;
+
 	/** Returns the Skeletal Mesh of the Bomber character. */
 	UFUNCTION(BlueprintPure, Category = "C++")
 	class UMySkeletalMeshComponent* GetMySkeletalMeshComponent() const;


### PR DESCRIPTION
https://trello.com/c/9G2jjcZ6/952-priobug-overlay-widget-is-not-disappearing-in-the-cut-scenes?filter=member:valeriirotermel

Initially, I was planning to extend the UNMMSpotComponent::IsSpotAvailable() method, but later, I  discovered that it is used even for skin changes, so it blocks skin changes. Now I am not sure if I need to add additional checks like in IsSpotAvailable: 

`return IsActive()
		&& MeshComponent
		&& MeshComponent->IsActive()
		&& MeshComponent->IsVisible()
		&& MeshComponent->IsSkinAvailable(MeshComponent->GetAppliedSkinIndex();
`
It will duplicate the functionality. 


https://github.com/user-attachments/assets/e951e134-6398-46c7-9587-c9336ac355b0

